### PR TITLE
allow switching language on rest api init by providing 'lang' or 'wpm…

### DIFF
--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -18,6 +18,20 @@ function wpmlretapi_init() {
 	if (!is_plugin_active('sitepress-multilingual-cms/sitepress.php')) {
 		return;
 	}
+	
+	$available_langs = wpml_get_active_languages_filter('', array('skip_missing' => false, ) );
+		
+	if ( ! empty( $available_langs ) && ! isset( $GLOBALS['icl_language_switched'] ) || ! $GLOBALS['icl_language_switched'] ) {
+		if ( isset( $_REQUEST['wpml_lang'] ) ) {
+			$lang = $_REQUEST['wpml_lang'];
+		} else if ( isset( $_REQUEST['lang'] ) ) {
+			$lang = $_REQUEST['lang'];
+		}
+		
+		if ( isset( $lang ) && in_array( $lang, array_keys( $available_langs ) ) ) {
+			do_action( 'wpml_switch_language', $lang );
+		}
+	}
 
 	// Add WPML fields to all post types
 	// Thanks to Roy Sivan for this trick.


### PR DESCRIPTION
…l_lang' parameter

This should make WPML aware of the requested language (if provided) and filter response objects accordingly. We check if `$GLOBALS['icl_language_switched']` is defined in case WPML starts doing this itself in future versions.