### PR TITLE
add link to output

### DIFF
--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -18,16 +18,16 @@ function wpmlrestapi_init() {
 	if (!is_plugin_active('sitepress-multilingual-cms/sitepress.php')) {
 		return;
 	}
-	
+
 	$available_langs = wpml_get_active_languages_filter('', array('skip_missing' => false, ) );
-		
+
 	if ( ! empty( $available_langs ) && ! isset( $GLOBALS['icl_language_switched'] ) || ! $GLOBALS['icl_language_switched'] ) {
 		if ( isset( $_REQUEST['wpml_lang'] ) ) {
 			$lang = $_REQUEST['wpml_lang'];
 		} else if ( isset( $_REQUEST['lang'] ) ) {
 			$lang = $_REQUEST['lang'];
 		}
-		
+
 		if ( isset( $lang ) && in_array( $lang, array_keys( $available_langs ) ) ) {
 			do_action( 'wpml_switch_language', $lang );
 		}
@@ -94,7 +94,15 @@ function wpmlrestapi_slug_get_translations( $object, $field_name, $request ) {
 			$href .= $thisPost->post_name . '/';
 		}
 
-		$translations[] = array('locale' => $language['default_locale'], 'id' => $thisPost->ID, 'post_title' => $thisPost->post_title, 'href' => $href);
+		$link = get_page_link($post_id);
+
+		$translations[] = array(
+			'locale' => $language['default_locale'],
+			'id' => $thisPost->ID,
+			'post_title' => $thisPost->post_title,
+			'href' => $href,
+			'link' => $link
+		);
 	}
 
 	return $translations;

--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -94,7 +94,7 @@ function wpmlrestapi_slug_get_translations( $object, $field_name, $request ) {
 			$href .= $thisPost->post_name . '/';
 		}
 
-		$link = get_page_link($post_id);
+		$link = get_permalink($post_id);
 
 		$translations[] = array(
 			'locale' => $language['default_locale'],


### PR DESCRIPTION
This PR adds 'link' to the output, generated by https://developer.wordpress.org/reference/functions/get_page_link/

I don't know why the `href` is created based on the `page_name`, when WP gives us a lot of functions to do this stuff. But I kept it in for people using this right now, and added `link` next to it.