### PR TITLE
Add filter hook to modify translation array

### DIFF
--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -129,7 +129,9 @@ class WPML_REST_API {
 				}
 			}
 
-			$translations[] = array('locale' => $language['default_locale'], 'id' => $thisPost->ID, 'post_title' => $thisPost->post_title, 'href' => $href);
+			$translation = array('locale' => $language['default_locale'], 'id' => $thisPost->ID, 'post_title' => $thisPost->post_title, 'href' => $href);
+			$translation = apply_filters( 'wpmlrestapi_get_translation', $translation, $thisPost, $language );
+			$translations[] = $translation;
 		}
 
 		return $translations;


### PR DESCRIPTION
# Overview

Adds the `wpmlrestapi_get_translation` filter to allow for modification of the translation array during `get_translations`. Rather than change the href filter or the existing logic, this new filter allows for a clean entrypoint to update the translation data.

## Details

* The filter is applied once for each translation. 
* The entire array is passed in along with the post and the language.

## Extra 🎁 

My editor is set to add a newline at the end of the file. Let me know if you'd like that removed before merging. 😁 

## Use Case Example

Our site uses a permalink manager plugin that returns a fully localized URL to the content. Using the existing `wpmlrestapi_translations_href` filter passes the URL through the rest of the function where it is incorrectly modified.
