### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,34 @@
 **Donate link:** http://shawnhooper.ca/  
 **Tags:** wpml, api, rest  
 **Requires at least:** 5.2  
-**Tested up to:** 6.0  
-**Requires PHP:** 7.0  
+**Tested up to:** 6.0.3 
+**Requires PHP:** 7.4  
 **Stable tag:** trunk  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
-Adds links to posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+Get translations details with the WP REST API on sites running WordPress & WPML
 
 ## Description ##
 
-Adds links to posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+This plugin adds links to pages and posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+
+It adds a "wpml_current_locale" string containing the locale code of the current response, and a "wpml_translations" array
+containing the available translations for this plugin.
 
 ## Screenshots ##
 
 1. This screenshot shows an excerpt of the JSON returned by the WP REST API when a page has translations available
 
 ## Changelog ##
+
+### 2.0.0 (2022-10-27) ###
+* Fixed: Permalink style /yyyy/mm/dd/post_name/ returns slug without the dates (reported by @lukas-hablitzel)
+* Change: array keys in the wpml_translations response are now the locale code instead of an integer
+* Updated PHP Style: Short array syntax
+* Updated PHP Style: Added return types to all methods
+* Updated PHP Style: Added types to all parameters
+* Updated PHP Style: replaced str_pos with str_contains and str_ends_with
 
 ### 1.1.4 (2022-05-31) ###
 * Update build tool dependencies to fix CVE-2022-1537, CVE-2022-0436 and CVE-2020-7729

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WPML REST API ===
 Contributors: shooper
 Donate link: http://shawnhooper.ca/
-Tags: wpml, api, rest
+Tags: wpml, api, rest, headless, multilingual, translations
 Requires at least: 5.2
 Tested up to: 6.0.3
 Requires PHP: 7.4

--- a/readme.txt
+++ b/readme.txt
@@ -3,23 +3,34 @@ Contributors: shooper
 Donate link: http://shawnhooper.ca/
 Tags: wpml, api, rest
 Requires at least: 5.2
-Tested up to: 6.0
-Requires PHP: 7.0
+Tested up to: 6.0.3
+Requires PHP: 7.4
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Adds links to posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+Get translations details with the WP REST API on sites running WordPress & WPML
 
 == Description ==
 
-Adds links to posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+This plugin adds links to pages and posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
+
+It adds a "wpml_current_locale" string containing the locale code of the current response, and a "wpml_translations" array
+containing the available translations for this plugin.
 
 == Screenshots ==
 
 1. This screenshot shows an excerpt of the JSON returned by the WP REST API when a page has translations available
 
 == Changelog ==
+
+= 2.0.0 (2022-10-27) =
+* Fixed: Permalink style /yyyy/mm/dd/post_name/ returns slug without the dates (reported by @lukas-hablitzel)
+* Change: array keys in the wpml_translations response are now the locale code instead of an integer
+* Updated PHP Style: Short array syntax
+* Updated PHP Style: Added return types to all methods
+* Updated PHP Style: Added types to all parameters
+* Updated PHP Style: replaced str_pos with str_contains and str_ends_with
 
 = 1.1.4 (2022-05-31) =
 * Update build tool dependencies to fix CVE-2022-1537, CVE-2022-0436 and CVE-2020-7729

--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -29,7 +29,7 @@ class WPML_REST_API {
 
 		$available_languages = wpml_get_active_languages_filter('', array('skip_missing' => false, ) );
 
-		if ( ! empty( $available_languages ) && ! isset( $GLOBALS['icl_language_switched'] ) || ! $GLOBALS['icl_language_switched'] ) {
+		if ( (!empty($available_languages) && !isset($GLOBALS['icl_language_switched'])) || ! $GLOBALS['icl_language_switched'] ) {
 			if ( isset( $_REQUEST['wpml_lang'] ) ) {
 				$lang = $_REQUEST['wpml_lang'];
 			} else if ( isset( $_REQUEST['lang'] ) ) {

--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -2,7 +2,7 @@
 
 /*
 Plugin Name: WPML REST API
-Version: 1.1.3
+Version: 2.0.0
 Description: Adds links to posts in other languages into the results of a WP REST API query for sites running the WPML plugin.
 Author: Shawn Hooper
 Author URI: https://profiles.wordpress.org/shooper
@@ -10,16 +10,17 @@ Author URI: https://profiles.wordpress.org/shooper
 
 namespace ShawnHooper\WPML;
 
-use WP_Post;
 use WP_REST_Request;
 use RuntimeException;
 
 class WPML_REST_API
 {
 
+    private array $translations = [];
+
     public function wordpress_hooks(): void
     {
-        add_action('rest_api_init', array($this, 'init'), 1000);
+        add_action('rest_api_init', [$this, 'init'], 1000);
     }
 
     public function init(): void
@@ -81,88 +82,8 @@ class WPML_REST_API
     }
 
     /**
-     * Calculate the relative path for this post, supports also nested pages
+     * REST API ENDPOINT Handler
      *
-     * @param WP_Post $thisPost
-     * @return string the relative path for this page e.g. `root-page/child-page`
-     */
-    public function calculate_rel_path(WP_Post $thisPost): string
-    {
-        $post_name = $thisPost->post_name;
-        if ($thisPost->post_parent > 0) {
-            $cur_post = get_post($thisPost->post_parent);
-            if (isset($cur_post)) {
-                $rel_path = $this->calculate_rel_path($cur_post);
-                return $rel_path . "/" . $post_name;
-            }
-        }
-        return $post_name;
-    }
-
-    /**
-     * Retrieve available translations
-     *
-     * @param array $object Details of current post.
-     * @param string $field_name Name of field.
-     * @param WP_REST_Request $request Current request
-     *
-     * @return array
-     * @noinspection PhpUnusedParameterInspection
-     */
-    public function get_translations(array $object, string $field_name, WP_REST_Request $request): array
-    {
-        $languages = apply_filters('wpml_active_languages', null);
-        $translations = [];
-        $show_on_front = get_option('show_on_front');
-        $page_on_front = get_option('page_on_front');
-
-        foreach ($languages as $language) {
-            $post_id = wpml_object_id_filter($object['id'], 'post', false, $language['language_code']);
-            if ($post_id === null || $post_id === $object['id']) {
-                continue;
-            }
-            $thisPost = get_post($post_id);
-
-            // Only show published posts
-            if ('publish' !== $thisPost->post_status) {
-                continue;
-            }
-
-            $href = apply_filters('WPML_filter_link', $language['url'], $language);
-            $href = apply_filters('wpmlrestapi_translations_href', $href, $thisPost);
-            $href = trailingslashit($href);
-
-
-            if (!('page' === $show_on_front && $object['id'] === $page_on_front)) {
-
-                $postUrl = $this->calculate_rel_path($thisPost);
-                if (str_contains($href, '?')) {
-                    $href = str_replace('?', '/' . $postUrl . '/?', $href);
-                } else {
-                    if (!str_ends_with($href, '/')) {
-                        $href .= '/';
-                    }
-
-                    $href .= $postUrl . '/';
-                }
-
-                $translation = [
-                    'locale' => $language['default_locale'],
-                    'id' => $thisPost->ID,
-                    'slug' => $thisPost->post_name,
-                    'post_title' => $thisPost->post_title,
-                    'href' => $href,
-                ];
-
-                $translation = apply_filters('wpmlrestapi_get_translation', $translation, $thisPost, $language);
-                $translations[$language['default_locale']] = $translation;
-            }
-        }
-
-        return $translations;
-    }
-
-    /**
      * Retrieve the current locale
      *
      * @param array $object Details of current post.
@@ -176,12 +97,57 @@ class WPML_REST_API
     public function get_current_locale(array $object, string $field_name, WP_REST_Request $request): string
     {
         $langInfo = wpml_get_language_information($object);
-
         if (is_wp_error($langInfo)) {
             throw new RuntimeException('Unable to retrieve the current locale');
         }
-
         return $langInfo['locale'];
+    }
+
+    /**
+     * REST API ENDPOINT Handler
+     *
+     * Retrieve available translations
+     *
+     * @param array $object Details of current post.
+     * @param string $field_name Name of field.
+     * @param WP_REST_Request $request Current request
+     *
+     * @return array
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function get_translations(array $object, string $field_name, WP_REST_Request $request): array
+    {
+        $languages = apply_filters('wpml_active_languages', null);
+
+        foreach ($languages as $language) {
+            $this->get_translations_for_language($object, $language);
+        }
+
+        return $this->translations;
+    }
+
+    /**
+     * @param array $object
+     * @param array $language
+     * @return void
+     */
+    private function get_translations_for_language(array $object, array $language) : void {
+        $post_id = wpml_object_id_filter($object['id'], 'post', false, $language['language_code']);
+        if ($post_id === null || $post_id === $object['id']) {
+            return;
+        }
+
+        $thisPost = get_post($post_id);
+
+        $translation = [
+            'locale' => $language['default_locale'],
+            'id' => $thisPost->ID,
+            'slug' => $thisPost->post_name,
+            'post_title' => $thisPost->post_title,
+            'href' => get_permalink($thisPost),
+        ];
+
+        $this->translations[$language['default_locale']] = apply_filters('wpmlrestapi_get_translation', $translation, $thisPost, $language);
     }
 }
 

--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -12,158 +12,177 @@ namespace ShawnHooper\WPML;
 
 use WP_Post;
 use WP_REST_Request;
+use RuntimeException;
 
-class WPML_REST_API {
+class WPML_REST_API
+{
 
-	public function wordpress_hooks() {
-		add_action( 'rest_api_init', array($this, 'init'), 1000 );
-	}
+    public function wordpress_hooks(): void
+    {
+        add_action('rest_api_init', array($this, 'init'), 1000);
+    }
 
-	public function init() {
-		// Check if WPML is installed
-		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+    public function init(): void
+    {
+        // Check if WPML is installed
+        include_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
-		if (!is_plugin_active('sitepress-multilingual-cms/sitepress.php')) {
-			return;
-		}
+        if (!is_plugin_active('sitepress-multilingual-cms/sitepress.php')) {
+            return;
+        }
 
-		$available_languages = wpml_get_active_languages_filter('', array('skip_missing' => false, ) );
+        $available_languages = wpml_get_active_languages_filter('', ['skip_missing' => false]);
 
-		if ( (!empty($available_languages) && !isset($GLOBALS['icl_language_switched'])) || ! $GLOBALS['icl_language_switched'] ) {
-			if ( isset( $_REQUEST['wpml_lang'] ) ) {
-				$lang = $_REQUEST['wpml_lang'];
-			} else if ( isset( $_REQUEST['lang'] ) ) {
-				$lang = $_REQUEST['lang'];
-			}
+        if ((!empty($available_languages) && !isset($GLOBALS['icl_language_switched'])) || !$GLOBALS['icl_language_switched']) {
+            if (isset($_REQUEST['wpml_lang'])) {
+                $lang = $_REQUEST['wpml_lang'];
+            } else if (isset($_REQUEST['lang'])) {
+                $lang = $_REQUEST['lang'];
+            }
 
-			if ( isset( $lang ) && in_array( $lang, array_keys( $available_languages ) ) ) {
-				do_action( 'wpml_switch_language', $lang );
-			}
-		}
+            if (isset($lang) && array_key_exists($lang, $available_languages)) {
+                do_action('wpml_switch_language', $lang);
+            }
+        }
 
-		// Add WPML fields to all post types
-		// Thanks to Roy Sivan for this trick.
-		// http://www.roysivan.com/wp-api-v2-adding-fields-to-all-post-types/#.VsH0e5MrLcM
+        // Add WPML fields to all post types
+        // Thanks to Roy Sivan for this trick.
+        // http://www.roysivan.com/wp-api-v2-adding-fields-to-all-post-types/#.VsH0e5MrLcM
 
-		$post_types = get_post_types( array( 'public' => true, 'exclude_from_search' => false ), 'names' );
-		foreach( $post_types as $post_type ) {
-			$this->register_api_field($post_type);
-		}
-	}
+        $post_types = get_post_types(array('public' => true, 'exclude_from_search' => false));
+        foreach ($post_types as $post_type) {
+            $this->register_api_field($post_type);
+        }
+    }
 
-	public function register_api_field($post_type) {
-		register_rest_field( $post_type,
-			'wpml_current_locale',
-			array(
-				'get_callback'    => array($this, 'get_current_locale'),
-				'update_callback' => null,
-				'schema'          => null,
-			)
-		);
+    /**
+     * @param string $post_type
+     * @return void
+     */
+    public function register_api_field(string $post_type): void
+    {
+        register_rest_field($post_type,
+            'wpml_current_locale',
+            array(
+                'get_callback' => [$this, 'get_current_locale'],
+                'update_callback' => null,
+                'schema' => null,
+            )
+        );
 
-		register_rest_field( $post_type,
-			'wpml_translations',
-			array(
-				'get_callback'    => array($this, 'get_translations'),
-				'update_callback' => null,
-				'schema'          => null,
-			)
-		);
-	}
+        register_rest_field($post_type,
+            'wpml_translations',
+            array(
+                'get_callback' => [$this, 'get_translations'],
+                'update_callback' => null,
+                'schema' => null,
+            )
+        );
+    }
 
-	/**
-	 * Calculate the relative path for this post, supports also nested pages
-	 *
-	 * @param WP_Post $thisPost
-	 * @return string the relative path for this page e.g. `root-page/child-page`
-	 */
-	public function calculate_rel_path( WP_Post $thisPost)
-	{
-		$post_name = $thisPost->post_name;
-		if ($thisPost->post_parent > 0) {
-			$cur_post = get_post($thisPost->post_parent);
-			if (isset($cur_post)) {
-				$rel_path = $this->calculate_rel_path($cur_post);
-				return $rel_path . "/" . $post_name;
-			}
-		}
-		return $post_name;
-	}
+    /**
+     * Calculate the relative path for this post, supports also nested pages
+     *
+     * @param WP_Post $thisPost
+     * @return string the relative path for this page e.g. `root-page/child-page`
+     */
+    public function calculate_rel_path(WP_Post $thisPost): string
+    {
+        $post_name = $thisPost->post_name;
+        if ($thisPost->post_parent > 0) {
+            $cur_post = get_post($thisPost->post_parent);
+            if (isset($cur_post)) {
+                $rel_path = $this->calculate_rel_path($cur_post);
+                return $rel_path . "/" . $post_name;
+            }
+        }
+        return $post_name;
+    }
 
-	/**
-	 * Retrieve available translations
-	 *
-	 * @param array $object Details of current post.
-	 * @param string $field_name Name of field.
-	 * @param WP_REST_Request $request Current request
-	 *
-	 * @return array
-	 */
-	public function get_translations( array $object, $field_name, WP_REST_Request $request ) {
-		$languages = apply_filters('wpml_active_languages', null);
-		$translations = [];
-		$show_on_front = get_option( 'show_on_front' );
-		$page_on_front = get_option( 'page_on_front' );
+    /**
+     * Retrieve available translations
+     *
+     * @param array $object Details of current post.
+     * @param string $field_name Name of field.
+     * @param WP_REST_Request $request Current request
+     *
+     * @return array
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function get_translations(array $object, string $field_name, WP_REST_Request $request): array
+    {
+        $languages = apply_filters('wpml_active_languages', null);
+        $translations = [];
+        $show_on_front = get_option('show_on_front');
+        $page_on_front = get_option('page_on_front');
 
-		foreach ($languages as $language) {
-			$post_id = wpml_object_id_filter( $object['id'], 'post', false, $language['language_code'] );
-			if ( $post_id === null || $post_id == $object['id'] ) {
-				continue;
-			}
-			$thisPost = get_post( $post_id );
+        foreach ($languages as $language) {
+            $post_id = wpml_object_id_filter($object['id'], 'post', false, $language['language_code']);
+            if ($post_id === null || $post_id === $object['id']) {
+                continue;
+            }
+            $thisPost = get_post($post_id);
 
-			// Only show published posts
-			if ( 'publish' !== $thisPost->post_status ) {
-				continue;
-			}
+            // Only show published posts
+            if ('publish' !== $thisPost->post_status) {
+                continue;
+            }
 
-			$href = apply_filters( 'WPML_filter_link', $language['url'], $language );
-			$href = apply_filters( 'wpmlrestapi_translations_href', $href, $thisPost );
-			$href = trailingslashit( $href );
+            $href = apply_filters('WPML_filter_link', $language['url'], $language);
+            $href = apply_filters('wpmlrestapi_translations_href', $href, $thisPost);
+            $href = trailingslashit($href);
 
-			if ( ! ( 'page' == $show_on_front && $object['id'] == $page_on_front ) ) {
-				$postUrl = $this->calculate_rel_path( $thisPost );
-				if ( strpos( $href, '?' ) !== false ) {
-					$href = str_replace( '?', '/' . $postUrl . '/?', $href );
-				} else {
-					if ( substr( $href, - 1 ) !== '/' ) {
-						$href .= '/';
-					}
 
-					$href .= $postUrl . '/';
-				}
+            if (!('page' === $show_on_front && $object['id'] === $page_on_front)) {
 
-				$translation  = array(
-					'locale'     => $language['default_locale'],
-					'id'         => $thisPost->ID,
-					'slug'       => $thisPost->post_name,
-					'post_title' => $thisPost->post_title,
-					'href'       => $href,
-				);
+                $postUrl = $this->calculate_rel_path($thisPost);
+                if (str_contains($href, '?')) {
+                    $href = str_replace('?', '/' . $postUrl . '/?', $href);
+                } else {
+                    if (!str_ends_with($href, '/')) {
+                        $href .= '/';
+                    }
 
-				$translation = apply_filters( 'wpmlrestapi_get_translation', $translation, $thisPost, $language );
-				$translations[] = $translation;
-			}
-		}
+                    $href .= $postUrl . '/';
+                }
 
-		return $translations;
-	}
+                $translation = [
+                    'locale' => $language['default_locale'],
+                    'id' => $thisPost->ID,
+                    'slug' => $thisPost->post_name,
+                    'post_title' => $thisPost->post_title,
+                    'href' => $href,
+                ];
 
-	/**
-	 * Retrieve the current locale
-	 *
-	 * @param array $object Details of current post.
-	 * @param string $field_name Name of field.
-	 * @param WP_REST_Request $request Current request
-	 *
-	 * @return string
-	 */
-	public function get_current_locale( $object, $field_name, $request ) {
-		$langInfo = wpml_get_language_information($object);
-		if (!is_wp_error($langInfo)) {
-			return $langInfo['locale'];
-		}
-	}
+                $translation = apply_filters('wpmlrestapi_get_translation', $translation, $thisPost, $language);
+                $translations[$language['default_locale']] = $translation;
+            }
+        }
+
+        return $translations;
+    }
+
+    /**
+     * Retrieve the current locale
+     *
+     * @param array $object Details of current post.
+     * @param string $field_name Name of field.
+     * @param WP_REST_Request $request Current request
+     *
+     * @return string
+     * @throws RuntimeException
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function get_current_locale(array $object, string $field_name, WP_REST_Request $request): string
+    {
+        $langInfo = wpml_get_language_information($object);
+
+        if (is_wp_error($langInfo)) {
+            throw new RuntimeException('Unable to retrieve the current locale');
+        }
+
+        return $langInfo['locale'];
+    }
 }
 
 $GLOBALS['WPML_REST_API'] = new WPML_REST_API();


### PR DESCRIPTION
* Fixed: Permalink style /yyyy/mm/dd/post_name/ returns slug without the dates (Fixes #22)
* Change: array keys in the wpml_translations response are now the locale code instead of an integer
* Updated PHP Style: Short array syntax
* Updated PHP Style: Added return types to all methods
* Updated PHP Style: Added types to all parameters
* Updated PHP Style: replaced str_pos with str_contains and str_ends_with
